### PR TITLE
feat: Task 2 - ヘルスチェックエンドポイント実装

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,3 +1,9 @@
 from fastapi import FastAPI
 
 app = FastAPI(title="商品管理API")
+
+
+@app.get("/health", status_code=200)
+async def health_check() -> dict[str, str]:
+    """APIのヘルスチェック"""
+    return {"status": "ok"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,3 +119,8 @@ exclude = ["**/node_modules", "**/__pycache__", ".venv"]
 reportMissingTypeStubs = false
 typeCheckingMode = "basic"
 
+[dependency-groups]
+dev = [
+    "fastapi>=0.115.13",
+]
+

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -1,6 +1,20 @@
 import pytest
+from httpx import ASGITransport, AsyncClient
+
+from api.main import app
 
 
-def test_initial_setup_is_ok() -> None:
-    """テスト環境が正しくセットアップされていることを確認するための基本的なテスト。"""
-    assert True
+@pytest.mark.anyio
+async def test_health_check_returns_200() -> None:
+    """/healthエンドポイントはステータスコード200を返す"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/health")
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_health_check_returns_ok_status() -> None:
+    """/healthエンドポイントは{"status": "ok"}を返す"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/health")
+    assert response.json() == {"status": "ok"}

--- a/uv.lock
+++ b/uv.lock
@@ -257,6 +257,11 @@ ui = [
     { name = "streamlit" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "fastapi" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anyio", marker = "extra == 'dev'", specifier = ">=3.0.0" },
@@ -278,6 +283,9 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'api'", specifier = ">=0.23.0" },
 ]
 provides-extras = ["api", "ui", "dev", "all"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "fastapi", specifier = ">=0.115.13" }]
 
 [[package]]
 name = "distlib"


### PR DESCRIPTION
## 概要
Task #2 の実装です。
APIサーバーが正常に稼働しているかを確認するためのヘルスチェックエンドポイントをTDDで実装しました。

## 関連Issue
Fixes #2

## 変更内容
- `GET /health` エンドポイントのテストを追加
- `GET /health` エンドポイントの実装
- テスト実行に必要な `fastapi` を開発依存関係に追加