### PR TITLE
feat: Task 3 - 商品データモデルと記憶域の準備

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ProductModel(BaseModel):
+    """商品データモデル"""
+
+    id: int = Field(..., description="商品ID")
+    name: str = Field(..., min_length=1, description="商品名")
+    price: float = Field(..., gt=0, description="単価")
+    created_at: datetime = Field(default_factory=datetime.now, description="作成日時")

--- a/api/storage.py
+++ b/api/storage.py
@@ -1,0 +1,19 @@
+from .models import ProductModel
+
+
+class InMemoryStorage:
+    """インメモリストレージクラス"""
+
+    def __init__(self) -> None:
+        self._items: dict[int, ProductModel] = {}
+        self._next_id: int = 1
+
+    def create_product(self, product: ProductModel) -> ProductModel:
+        """商品を新規作成する（ダミー）"""
+        # Task 4で実装
+        raise NotImplementedError
+
+    def get_product(self, product_id: int) -> ProductModel | None:
+        """商品IDで商品を取得する（ダミー）"""
+        # Task 5で実装
+        raise NotImplementedError


### PR DESCRIPTION
## 概要
Task #3 の実装です。
アプリケーションで扱う商品データの構造を定義し、そのデータを一時的に保存するための仕組みを準備しました。

## 関連Issue
Fixes #3

## 変更内容
- Pydanticを使い、`api/models.py` に商品モデル (`ProductModel`) を定義
- `api/storage.py` にインメモリで商品を管理するクラス (`InMemoryStorage`) を作成