### PR TITLE
feat: Task 4 - 商品作成エンドポイント実装

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,9 +1,20 @@
 from fastapi import FastAPI
 
+from .models import CreateProductRequest, ProductModel
+from .storage import InMemoryStorage
+
 app = FastAPI(title="商品管理API")
+storage = InMemoryStorage()
 
 
 @app.get("/health", status_code=200)
 async def health_check() -> dict[str, str]:
     """APIのヘルスチェック"""
     return {"status": "ok"}
+
+
+@app.post("/items", response_model=ProductModel, status_code=201)
+async def create_product(request: CreateProductRequest) -> ProductModel:
+    """商品を新規作成する"""
+    product = storage.create_product(name=request.name, price=request.price)
+    return product

--- a/api/models.py
+++ b/api/models.py
@@ -10,3 +10,10 @@ class ProductModel(BaseModel):
     name: str = Field(..., min_length=1, description="商品名")
     price: float = Field(..., gt=0, description="単価")
     created_at: datetime = Field(default_factory=datetime.now, description="作成日時")
+
+
+class CreateProductRequest(BaseModel):
+    """商品作成リクエストモデル"""
+
+    name: str = Field(..., min_length=1, description="商品名")
+    price: float = Field(..., gt=0, description="単価")

--- a/api/storage.py
+++ b/api/storage.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from .models import ProductModel
 
 
@@ -8,10 +10,12 @@ class InMemoryStorage:
         self._items: dict[int, ProductModel] = {}
         self._next_id: int = 1
 
-    def create_product(self, product: ProductModel) -> ProductModel:
-        """商品を新規作成する（ダミー）"""
-        # Task 4で実装
-        raise NotImplementedError
+    def create_product(self, name: str, price: float) -> ProductModel:
+        """商品を新規作成する"""
+        product = ProductModel(id=self._next_id, name=name, price=price, created_at=datetime.now())
+        self._items[product.id] = product
+        self._next_id += 1
+        return product
 
     def get_product(self, product_id: int) -> ProductModel | None:
         """商品IDで商品を取得する（ダミー）"""

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -18,3 +18,39 @@ async def test_health_check_returns_ok_status() -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.get("/health")
     assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.anyio
+async def test_create_product_returns_201() -> None:
+    """POST /items はステータスコード 201 を返す"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/items", json={"name": "テスト商品", "price": 1000})
+    assert response.status_code == 201
+
+
+@pytest.mark.anyio
+async def test_create_product_returns_created_product() -> None:
+    """POST /items は作成された商品情報を返す"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/items", json={"name": "テスト商品", "price": 1000})
+    data = response.json()
+    assert data["name"] == "テスト商品"
+    assert data["price"] == 1000
+    assert "id" in data
+    assert "created_at" in data
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("name", "price"),
+    [
+        ("", 1000),  # 名前が空
+        ("テスト商品", 0),  # 価格が0
+        ("テスト商品", -1),  # 価格が負
+    ],
+)
+async def test_create_product_with_invalid_data_returns_422(name: str, price: float) -> None:
+    """不正なデータで商品を作成しようとすると422エラーを返す"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/items", json={"name": name, "price": price})
+    assert response.status_code == 422


### PR DESCRIPTION
## 概要
Task #4 の実装です。
新しい商品をシステムに登録するためのAPIエンドポイントをTDDで実装しました。

## 関連Issue
Fixes #4

## 変更内容
- `POST /items` エンドポイントを実装
- 商品作成ロジックを `InMemoryStorage` に実装
- 商品作成リクエスト用のPydanticモデルを追加
- 正常系およびバリデーションエラーのテストを追加