### PR TITLE
feat: Task 5 - 商品取得エンドポイント実装

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
 from .models import CreateProductRequest, ProductModel
 from .storage import InMemoryStorage
@@ -17,4 +17,13 @@ async def health_check() -> dict[str, str]:
 async def create_product(request: CreateProductRequest) -> ProductModel:
     """商品を新規作成する"""
     product = storage.create_product(name=request.name, price=request.price)
+    return product
+
+
+@app.get("/items/{product_id}", response_model=ProductModel)
+async def get_product(product_id: int) -> ProductModel:
+    """商品IDで商品を取得する"""
+    product = storage.get_product(product_id=product_id)
+    if product is None:
+        raise HTTPException(status_code=404, detail="Product not found")
     return product

--- a/api/storage.py
+++ b/api/storage.py
@@ -18,6 +18,5 @@ class InMemoryStorage:
         return product
 
     def get_product(self, product_id: int) -> ProductModel | None:
-        """商品IDで商品を取得する（ダミー）"""
-        # Task 5で実装
-        raise NotImplementedError
+        """商品IDで商品を取得する"""
+        return self._items.get(product_id)

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -54,3 +54,30 @@ async def test_create_product_with_invalid_data_returns_422(name: str, price: fl
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post("/items", json={"name": name, "price": price})
     assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_get_product_with_existing_id_returns_200_and_product() -> None:
+    """存在するIDで商品を取得すると200と商品情報を返す"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # Arrange: まず商品を作成
+        create_response = await client.post(
+            "/items", json={"name": "取得テスト用商品", "price": 500}
+        )
+        created_product = create_response.json()
+        product_id = created_product["id"]
+
+        # Act: 作成した商品を取得
+        get_response = await client.get(f"/items/{product_id}")
+
+    # Assert
+    assert get_response.status_code == 200
+    assert get_response.json() == created_product
+
+
+@pytest.mark.anyio
+async def test_get_product_with_non_existing_id_returns_404() -> None:
+    """存在しないIDで商品を取得しようとすると404エラーを返す"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/items/9999")  # 存在しないであろうID
+    assert response.status_code == 404


### PR DESCRIPTION
## 概要
Task #5 の実装です。
IDを指定して特定の商品情報を取得するためのAPIエンドポイントをTDDで実装しました。

これで全ての基本機能の実装が完了です🎉

## 関連Issue
Fixes #5

## 変更内容
- `GET /items/{id}` エンドポイントを実装
- 商品取得ロジックを `InMemoryStorage` に実装
- 正常系および404エラーのテストを追加