### PR TITLE
refactor: Task 8 - UIコードのリファクタリング

### DIFF
--- a/ui/main.py
+++ b/ui/main.py
@@ -1,68 +1,93 @@
 import httpx
 import streamlit as st
+from pydantic import BaseModel, Field
 
 # --- 定数 ---
 API_BASE_URL = "http://localhost:8000"
 
-# --- UI描画 ---
-st.title("商品管理UI")
 
-# --- タブの作成 ---
-tab1, tab2 = st.tabs(["商品登録", "商品検索"])
+# --- Pydanticモデル ---
+class ProductCreate(BaseModel):
+    """商品作成APIリクエスト用のデータモデル"""
+
+    name: str = Field(..., min_length=1, description="商品名")
+    price: float = Field(..., gt=0, description="単価")
 
 
-# --- 商品登録タブ ---
-with tab1:
+# --- APIクライアント ---
+def handle_api_error(e: httpx.HTTPError, context: str) -> None:
+    """APIエラーを処理し、Streamlitにメッセージを表示する"""
+    if isinstance(e, httpx.HTTPStatusError):
+        if e.response.status_code == 404:
+            st.warning(f"⚠️ {context} は見つかりませんでした。")
+        else:
+            data = e.response.json()
+            st.error(f"処理に失敗しました: {data.get('detail', '不明なエラー')}")
+    elif isinstance(e, httpx.RequestError):
+        st.error("APIサーバーに接続できません。サーバーを起動してください。")
+
+
+def register_product(product: ProductCreate) -> None:
+    """商品をAPIに登録する"""
+    try:
+        response = httpx.post(f"{API_BASE_URL}/items", json=product.model_dump(), timeout=5)
+        response.raise_for_status()
+        st.success(f"商品 `{product.name}` を登録しました。")
+        st.json(response.json())
+    except httpx.HTTPError as e:
+        handle_api_error(e, f"商品 {product.name}")
+
+
+def search_product(product_id: int) -> None:
+    """商品をIDでAPIから検索する"""
+    try:
+        response = httpx.get(f"{API_BASE_URL}/items/{product_id}", timeout=5)
+        response.raise_for_status()
+        product = response.json()
+        st.success(f"商品ID `{product['id']}` の情報が見つかりました。")
+        st.json(product)
+    except httpx.HTTPError as e:
+        handle_api_error(e, f"商品ID {product_id}")
+
+
+# --- UIコンポーネント ---
+def product_registration_tab() -> None:
+    """商品登録タブのUI"""
     st.header("商品を登録する")
-
-    with st.form("create_product_form", clear_on_submit=True):
-        name = st.text_input("商品名", placeholder="例: 新しいペン")
-        price = st.number_input("価格（円）", min_value=1, step=1)
+    with st.form("product_registration_form", clear_on_submit=True):
+        name = st.text_input("商品名", key="product_name")
+        price = st.number_input("価格（円）", min_value=0.0, step=100.0, key="product_price")
         submitted = st.form_submit_button("商品を登録する")
 
-    if submitted:
-        if not name:
-            st.error("商品名を入力してください。")
-        else:
-            request_body = {"name": name, "price": price}
+        if submitted:
             try:
-                response = httpx.post(f"{API_BASE_URL}/items", json=request_body, timeout=5)
-                response.raise_for_status()  # HTTPエラーがあれば例外を発生させる
-
-                created_product = response.json()
-                st.success(
-                    f"**登録完了！**\n\n"
-                    f"- 商品「{created_product['name']}」を登録しました。\n"
-                    f"- **商品ID:** `{created_product['id']}`"
-                )
-            except httpx.HTTPStatusError as e:
-                # バリデーションエラーなど、APIが返すエラー
-                data = e.response.json()
-                st.error(f"登録に失敗しました: {data.get('detail', '不明なエラー')}")
-            except httpx.RequestError:
-                # ネットワークエラーなど
-                st.error("APIサーバーに接続できません。サーバーを起動してください。")
+                product_data = ProductCreate(name=name, price=price)
+                register_product(product_data)
+            except ValueError as e:
+                st.error(f"入力値が無効です: {e}")
 
 
-# --- 商品検索タブ ---
-with tab2:
+def product_search_tab() -> None:
+    """商品検索タブのUI"""
     st.header("商品を検索する")
-
     product_id_input = st.number_input("商品ID", min_value=1, step=1, key="search_product_id")
-    if st.button("商品を検索する") and product_id_input:
-        try:
-            response = httpx.get(f"{API_BASE_URL}/items/{product_id_input}", timeout=5)
-            response.raise_for_status()
+    if st.button("商品を検索する"):
+        search_product(int(product_id_input))
 
-            product = response.json()
-            st.success(f"商品ID `{product['id']}` の情報が見つかりました。")
-            st.json(product)
 
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 404:
-                st.warning(f"⚠️ 商品ID `{product_id_input}` は見つかりませんでした。")
-            else:
-                data = e.response.json()
-                st.error(f"検索に失敗しました: {data.get('detail', '不明なエラー')}")
-        except httpx.RequestError:
-            st.error("APIサーバーに接続できません。サーバーを起動してください。")
+# --- メインアプリケーション ---
+def main() -> None:
+    """Streamlitアプリケーションのメイン関数"""
+    st.title("商品管理アプリ")
+
+    tab1, tab2 = st.tabs(["商品登録", "商品検索"])
+
+    with tab1:
+        product_registration_tab()
+
+    with tab2:
+        product_search_tab()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要
Task #13 の実装

## 関連Issue
Fixes #13

## 実装内容
- ✅ APIクライアントロジックを独立した関数に分離 (`register_product`, `search_product`)
- ✅ エラーハンドリングを共通関数化 (`handle_api_error`)
- ✅ 各タブのUI表示を独立した関数に分離 (`product_registration_tab`, `product_search_tab`)
- ✅ `main`関数を導入し、全体の見通しを改善